### PR TITLE
Remove `mode` parameter

### DIFF
--- a/packages/datacommons-mcp/datacommons_mcp/clients.py
+++ b/packages/datacommons-mcp/datacommons_mcp/clients.py
@@ -473,12 +473,7 @@ class DCClient:
             if "/topic/" in sv_dcid:
                 # Only include topics that exist in the topic store
                 if self.topic_store and sv_dcid in self.topic_store.topics_by_dcid:
-                    for variable in self.topic_store.get_topic_variables(sv_dcid):
-                        if variable not in variable_set:
-                            variables.append(variable)
-                            variable_set.add(variable)
-                    else:
-                        topics.append(sv_dcid)
+                    topics.append(sv_dcid)
             else:
                 variables.append(sv_dcid)
                 variable_set.add(sv_dcid)

--- a/packages/datacommons-mcp/datacommons_mcp/clients.py
+++ b/packages/datacommons-mcp/datacommons_mcp/clients.py
@@ -357,14 +357,12 @@ class DCClient:
     async def fetch_indicators(
         self,
         query: str,
-        mode: SearchMode,
         place_dcids: list[str] = None,
+        include_topics: bool = True,
         max_results: int = 10,
     ) -> dict:
         """
         Search for indicators matching a query, optionally filtered by place existence.
-        When mode is SearchMode.LOOKUP, return variables only.
-        When mode is SearchMode.BROWSE, return both topics and variables.
         When place_dcids are specified, filter the results by place existence.
 
         Returns:
@@ -373,8 +371,12 @@ class DCClient:
         # Search for more results than we need to ensure we get enough topics and variables.
         # The factor of 2 is arbitrary and we can adjust it (make it configurable?) as needed.
         max_search_results = max_results * 2
-        # Search for indicators - it returns topics and / or variables based on the mode.
-        search_results = await self._search_indicators(query, mode, max_search_results)
+        # Search for indicators - it returns topics and / or variables.
+        search_results = await self._search_indicators(
+            query=query,
+            include_topics=include_topics,
+            max_results=max_search_results,
+        )
 
         # Separate topics and variables
         topics = search_results.get("topics", [])
@@ -446,21 +448,20 @@ class DCClient:
         }
 
     async def _search_indicators(
-        self, query: str, mode: SearchMode, max_results: int = 10
+        self, query: str, include_topics: bool = True, max_results: int = 10
     ) -> dict:
         """
         Search for topics and variables using search_svs.
-        When mode is SearchMode.LOOKUP, expand topics to variables.
         """
-        logger.info(f"Searching for indicators with query: {query} and mode: {mode}")
+        logger.info(f"Searching for indicators with query: {query}")
         search_results = await self.search_svs(
-            [query], skip_topics=False, max_results=max_results
+            [query], skip_topics=not include_topics, max_results=max_results
         )
         results = search_results.get(query, [])
 
         topics = []
         variables = []
-        # Track variables to avoid duplicates when expanding topics to variables in lookup mode.
+        # Track variables to avoid duplicates when expanding topics to variables.
         variable_set: set[str] = set()
 
         for result in results:
@@ -472,12 +473,10 @@ class DCClient:
             if "/topic/" in sv_dcid:
                 # Only include topics that exist in the topic store
                 if self.topic_store and sv_dcid in self.topic_store.topics_by_dcid:
-                    # In lookup mode, expand topics to variables.
-                    if mode == SearchMode.LOOKUP:
-                        for variable in self.topic_store.get_topic_variables(sv_dcid):
-                            if variable not in variable_set:
-                                variables.append(variable)
-                                variable_set.add(variable)
+                    for variable in self.topic_store.get_topic_variables(sv_dcid):
+                        if variable not in variable_set:
+                            variables.append(variable)
+                            variable_set.add(variable)
                     else:
                         topics.append(sv_dcid)
             else:

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -446,7 +446,7 @@ async def search_indicators(
         **If `include_topics = False`**: Returns only variables
 
     **Processing the Response:**
-    * **Topics**: Collections of variables and sub-topics (browse mode only). Use the dcid_name_mappings to get readable names.
+    * **Topics**: Collections of variables and sub-topics. Use the dcid_name_mappings to get readable names.
     * **Variables**: Individual data indicators. Use the dcid_name_mappings to get readable names.
     * **places_with_data**: Only present when place filtering was performed. Shows which requested places have data for each indicator.
     * **Filter and rank**: Treat all results as candidates and filter/rank based on user context.

--- a/packages/datacommons-mcp/datacommons_mcp/services.py
+++ b/packages/datacommons-mcp/datacommons_mcp/services.py
@@ -124,14 +124,14 @@ async def get_observations(
 async def search_indicators(
     client: DCClient,
     query: str,
-    mode: SearchModeType | None = None,
     places: list[str] | None = None,
+    include_topics: bool = True,
     maybe_bilateral: bool = False,
     per_search_limit: int = 10,
 ) -> SearchResponse:
-    """Search for topics and/or variables based on mode."""
-    # Validate parameters and convert mode to enum
-    search_mode = _validate_search_parameters(mode, per_search_limit)
+    """Search for topics and/or variables."""
+    # Validate parameters
+    _validate_search_parameters(per_search_limit)
 
     # Resolve place names to DCIDs
     place_dcids_map = await _resolve_places(client, places)
@@ -140,7 +140,10 @@ async def search_indicators(
     search_tasks = _create_search_tasks(query, places, maybe_bilateral, place_dcids_map)
 
     search_result = await _search_indicators(
-        client, search_mode, search_tasks, per_search_limit
+        client=client,
+        include_topics=include_topics,
+        search_tasks=search_tasks,
+        per_search_limit=per_search_limit,
     )
 
     # Collect all DCIDs for lookups
@@ -210,37 +213,19 @@ def _create_search_tasks(
 
 
 def _validate_search_parameters(
-    mode: SearchModeType | None,
     per_search_limit: int,
-) -> SearchMode:
-    """Validate search parameters and convert mode to enum.
+) -> None:
+    """Validate search parameters
 
     Args:
-        mode: Search mode string or None
         per_search_limit: Maximum results per search
-
-    Returns:
-        SearchMode enum value
 
     Raises:
         ValueError: If any parameter validation fails
     """
-    # Convert string mode to enum for validation and comparison, defaulting to browse if not specified
-    if not mode:
-        search_mode = SearchMode.BROWSE
-    else:
-        try:
-            search_mode = SearchMode(mode)
-        except ValueError as e:
-            raise ValueError(
-                f"mode must be either '{SearchMode.BROWSE.value}' or '{SearchMode.LOOKUP.value}'"
-            ) from e
-
     # Validate per_search_limit parameter
     if not 1 <= per_search_limit <= 100:
         raise ValueError("per_search_limit must be between 1 and 100")
-
-    return search_mode
 
 
 async def _resolve_places(
@@ -303,8 +288,8 @@ def _collect_all_dcids(
 
 async def _search_indicators(
     client: DCClient,
-    mode: SearchMode,
     search_tasks: list[SearchTask],
+    include_topics: bool,
     per_search_limit: int = 10,
 ) -> SearchResult:
     """Search for indicators matching a query, optionally filtered by place existence.
@@ -317,8 +302,8 @@ async def _search_indicators(
     for search_task in search_tasks:
         task = client.fetch_indicators(
             query=search_task.query,
-            mode=mode,
             place_dcids=search_task.place_dcids,
+            include_topics=include_topics,
             max_results=per_search_limit,
         )
         tasks.append(task)

--- a/packages/datacommons-mcp/tests/test_dc_client.py
+++ b/packages/datacommons-mcp/tests/test_dc_client.py
@@ -28,7 +28,6 @@ import pytest
 from datacommons_client.client import DataCommonsClient
 from datacommons_mcp.clients import DCClient, create_dc_client
 from datacommons_mcp.data_models.enums import SearchScope
-from datacommons_mcp.data_models.search import SearchMode
 from datacommons_mcp.data_models.observations import (
     DateRange,
     ObservationApiResponse,
@@ -462,7 +461,9 @@ class TestDCClientFetchIndicators:
     """Tests for the fetch_indicators method of DCClient."""
 
     @pytest.mark.asyncio
-    async def test_fetch_indicators_browse_mode_basic(self, mocked_datacommons_client):
+    async def test_fetch_indicators_include_topics_true(
+        self, mocked_datacommons_client
+    ):
         """Test basic functionality without place filtering."""
         # Arrange: Create client and mock search results
         client_under_test = DCClient(dc=mocked_datacommons_client)
@@ -501,7 +502,7 @@ class TestDCClientFetchIndicators:
 
         # Act: Call the method
         result = await client_under_test.fetch_indicators(
-            "test query", mode=SearchMode.BROWSE
+            "test query", include_topics=True
         )
 
         # Assert: Verify the response structure
@@ -527,7 +528,9 @@ class TestDCClientFetchIndicators:
         assert result["lookups"]["dc/variable/Count_Person"] == "Count of Persons"
 
     @pytest.mark.asyncio
-    async def test_fetch_indicators_lookup_mode_basic(self, mocked_datacommons_client):
+    async def test_fetch_indicators_include_topics_false(
+        self, mocked_datacommons_client
+    ):
         """Test basic functionality without place filtering."""
         # Arrange: Create client and mock search results
         client_under_test = DCClient(dc=mocked_datacommons_client)
@@ -535,8 +538,6 @@ class TestDCClientFetchIndicators:
         # Mock search_svs to return topics and variables
         mock_search_results = {
             "test query": [
-                {"SV": "dc/topic/Health", "CosineScore": 0.9},
-                {"SV": "dc/topic/Economy", "CosineScore": 0.8},
                 {"SV": "dc/variable/Count_Person", "CosineScore": 0.7},
                 {"SV": "dc/variable/Count_Household", "CosineScore": 0.6},
             ]
@@ -555,23 +556,15 @@ class TestDCClientFetchIndicators:
         }.get(dcid, dcid)
 
         # Mock topic data
-        client_under_test.topic_store.topics_by_dcid = {
-            "dc/topic/Health": Mock(
-                member_topics=[], variables=["dc/variable/Count_Person"]
-            ),
-            "dc/topic/Economy": Mock(
-                member_topics=[], variables=["dc/variable/Count_Household"]
-            ),
-        }
+        client_under_test.topic_store.topics_by_dcid = {}
 
-        client_under_test.topic_store.get_topic_variables.side_effect = lambda dcid: {
-            "dc/topic/Health": ["dc/variable/Count_Health"],
-            "dc/topic/Economy": ["dc/variable/Count_Economy"],
-        }.get(dcid, [])
+        client_under_test.topic_store.get_topic_variables.side_effect = (
+            lambda dcid: {}.get(dcid, [])
+        )
 
         # Act: Call the method
         result = await client_under_test.fetch_indicators(
-            "test query", mode=SearchMode.LOOKUP
+            "test query", include_topics=False
         )
 
         # Assert: Verify the response structure
@@ -583,22 +576,20 @@ class TestDCClientFetchIndicators:
         assert len(result["topics"]) == 0
 
         # Verify variables
-        assert len(result["variables"]) == 4
+        assert len(result["variables"]) == 2
         variable_dcids = [var["dcid"] for var in result["variables"]]
         assert variable_dcids == [
-            "dc/variable/Count_Health",
-            "dc/variable/Count_Economy",
             "dc/variable/Count_Person",
             "dc/variable/Count_Household",
         ]
 
         # Verify lookups
-        assert len(result["lookups"]) == 4
-        assert result["lookups"]["dc/variable/Count_Health"] == "Count of Health"
+        assert len(result["lookups"]) == 2
+        assert result["lookups"]["dc/variable/Count_Household"] == "Count of Households"
         assert result["lookups"]["dc/variable/Count_Person"] == "Count of Persons"
 
     @pytest.mark.asyncio
-    async def test_fetch_indicators_browse_mode_with_places(
+    async def test_fetch_indicators_include_topics_with_places(
         self, mocked_datacommons_client
     ):
         """Test functionality with place filtering."""
@@ -640,7 +631,7 @@ class TestDCClientFetchIndicators:
 
         # Act: Call the method with place filtering
         result = await client_under_test.fetch_indicators(
-            "test query", mode=SearchMode.BROWSE, place_dcids=["geoId/06", "geoId/36"]
+            "test query", place_dcids=["geoId/06", "geoId/36"], include_topics=True
         )
 
         # Assert: Verify that only variables with data are returned
@@ -776,7 +767,7 @@ class TestDCClientFetchIndicators:
 
         # Act: Call the method
         result = await client_under_test._search_indicators(
-            "test query", mode=SearchMode.BROWSE
+            "test query", include_topics=True
         )
 
         # Assert: Verify that only valid topics are returned
@@ -817,7 +808,7 @@ class TestDCClientFetchIndicators:
 
         # Act: Call the method
         result = await client_under_test._search_indicators(
-            "test query", mode=SearchMode.BROWSE
+            "test query", include_topics=True
         )
 
         # Assert: Verify that no topics are returned when topic store is None
@@ -848,7 +839,7 @@ class TestDCClientFetchIndicators:
         client_under_test.search_svs = AsyncMock(return_value=mock_search_results)
 
         result = await client_under_test._search_indicators(
-            "test query", mode=SearchMode.BROWSE, max_results=2
+            "test query", include_topics=True, max_results=2
         )
 
         # Verify that search_svs was called with max_results=2


### PR DESCRIPTION
This PR is stacked on top of PR #41. It should be rebased once #41 is merged. The differences between this PR and the code on PR #41 can be [viewed here](https://github.com/keyurva/dcagent-toolkit/compare/maybe-bilateral...ONEcampaign:agent-toolkit:remove-mode). 

This PR follows up on [this comment](https://github.com/datacommonsorg/agent-toolkit/pull/41#pullrequestreview-3197573891). It removes the 'mode' parameter in favour of an 'include_topics' boolean. 

The PR updates functions, the tool instructions, and tests accordingly.