### PR TITLE
Support GCS paths for server and tool instructions

### DIFF
--- a/packages/datacommons-mcp/.env.sample
+++ b/packages/datacommons-mcp/.env.sample
@@ -50,6 +50,7 @@ DC_TYPE=base
 # Path to directory containing markdown file overrides for server instructions and/or tool descriptions.
 # Supports partial overrides: only create files for the specific instructions or tools you want to replace. 
 # The system will fall back to package defaults for any file not found here.
+# Supports both local filesystem paths and Google Cloud Storage paths (e.g., gs://bucket/path).
 #
 # Expected structure inside this directory:
 # - server.md

--- a/packages/datacommons-mcp/datacommons_mcp/utils.py
+++ b/packages/datacommons-mcp/datacommons_mcp/utils.py
@@ -14,9 +14,14 @@
 
 import importlib.resources
 import logging
+from functools import cache
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import requests
+
+if TYPE_CHECKING:
+    from google.cloud import storage
 from datacommons_client.models.observation import Observation
 
 from datacommons_mcp.data_models.observations import DateRange, ObservationDate
@@ -93,31 +98,79 @@ def filter_by_date(
     return filtered_list
 
 
-def read_external_content(base_path: str, filename: str) -> str | None:
-    """Reads content from an external location (currently only local paths).
+@cache
+def _get_gcs_client() -> "storage.Client":
+    """Returns a cached GCS client instance."""
+    # Local import to avoid loading the module unless GCS is required
+    from google.cloud import storage
 
-    Args:
-        base_path: The base directory to look in.
-        filename: The name of the file to read (relative to base_path). Can include
-            subdirectories (e.g. "tools/search_indicators.md").
+    return storage.Client()
 
-    Returns:
-        The content of the file as a string, or None if the file does not exist
-        or cannot be read.
 
-    Example:
-        >>> content = read_external_content("/path/to/instructions", "server.md")
-    """
-    # TODO(keyurs): Add support for GCS if needed. This is useful for Custom DCs deployed in the cloud.
+def _read_local_content(path: Path) -> str | None:
+    """Reads content from a local file path."""
     try:
-        path = Path(base_path) / filename
         if path.exists() and path.is_file():
             return path.read_text(encoding="utf-8")
     except Exception as e:
+        logger.warning("Failed to read local file %s: %s", path, e)
+    return None
+
+
+def _read_gcs_content(bucket_name: str, blob_path: str) -> str | None:
+    """Reads content from a GCS blob."""
+    from google.cloud.exceptions import NotFound
+
+    try:
+        client = _get_gcs_client()
+        bucket = client.bucket(bucket_name)
+        blob = bucket.blob(blob_path)
+        return blob.download_as_text(encoding="utf-8")
+    except NotFound:
         logger.warning(
-            "Failed to read external instruction %s from %s: %s", filename, base_path, e
+            "GCS blob %s not found in bucket %s. Falling back to default.",
+            blob_path,
+            bucket_name,
+        )
+        return None
+    except Exception as e:
+        logger.warning(
+            "Failed to read GCS blob %s from bucket %s: %s",
+            blob_path,
+            bucket_name,
+            e,
         )
     return None
+
+
+def _parse_gcs_path(base_path: str, filename: str) -> tuple[str, str] | None:
+    """Parses a GCS path and returns (bucket_name, blob_path) if valid."""
+    if not base_path.startswith("gs://"):
+        return None
+    parts = base_path[5:].split("/", 1)
+    bucket_name = parts[0]
+    prefix = parts[1] if len(parts) > 1 else ""
+    blob_path = f"{prefix}/{filename}" if prefix else filename
+    return bucket_name, blob_path
+
+
+def read_external_content(base_path: str, filename: str) -> str | None:
+    """Reads content from an external location (local or GCS).
+
+    Args:
+        base_path: The base directory or GCS path (gs://bucket/prefix) to look in.
+        filename: The name of the file to read (relative to base_path).
+
+    Returns:
+        The content of the file as a string, or None if the file does not exist.
+    """
+    gcs_info = _parse_gcs_path(base_path, filename)
+    if gcs_info:
+        bucket_name, blob_path = gcs_info
+        return _read_gcs_content(bucket_name, blob_path)
+
+    path = Path(base_path) / filename
+    return _read_local_content(path)
 
 
 def read_package_content(package: str, filename: str) -> str:

--- a/packages/datacommons-mcp/pyproject.toml
+++ b/packages/datacommons-mcp/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pydantic-settings",
     "python-dateutil>=2.9.0.post0",
     "python-dotenv>=1.1.1",
+    "google-cloud-storage",
 ]
 urls = {Homepage = "https://github.com/datacommonsorg/agent-toolkit"}
 license = {file = "LICENSE"}

--- a/packages/datacommons-mcp/tests/test_utils.py
+++ b/packages/datacommons-mcp/tests/test_utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 import requests
 from datacommons_client.models.observation import Observation
@@ -20,6 +22,7 @@ from datacommons_mcp.data_models.observations import DateRange
 from datacommons_mcp.exceptions import APIKeyValidationError, InvalidAPIKeyError
 from datacommons_mcp.utils import (
     VALIDATION_API_PATH,
+    _get_gcs_client,
     filter_by_date,
     read_external_content,
     read_package_content,
@@ -85,6 +88,22 @@ class TestValidateAPIKey:
 
 
 class TestReadContent:
+    @pytest.fixture
+    def mock_gcs(self):
+        with patch("google.cloud.storage.Client") as mock_client_class:
+            _get_gcs_client.cache_clear()
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+
+            mock_bucket = MagicMock()
+            mock_client.bucket.return_value = mock_bucket
+
+            mock_blob = MagicMock()
+            mock_bucket.blob.return_value = mock_blob
+            mock_blob.download_as_text.return_value = "gcs content"
+
+            yield mock_client, mock_bucket, mock_blob
+
     def test_read_external_content_success(self, tmp_path, create_test_file):
         create_test_file("test.md", "content")
         assert read_external_content(str(tmp_path), "test.md") == "content"
@@ -96,6 +115,36 @@ class TestReadContent:
 
     def test_read_external_content_missing(self, tmp_path):
         assert read_external_content(str(tmp_path), "missing.md") is None
+
+    def test_read_external_content_gcs_success(self, mock_gcs):
+        mock_client, mock_bucket, mock_blob = mock_gcs
+        mock_blob.download_as_text.return_value = "custom content 1"
+
+        content = read_external_content("gs://my-bucket/path", "test.md")
+
+        assert content == "custom content 1"
+        mock_client.bucket.assert_called_once_with("my-bucket")
+        mock_bucket.blob.assert_called_once_with("path/test.md")
+
+    def test_read_external_content_gcs_success_no_prefix(self, mock_gcs):
+        mock_client, mock_bucket, mock_blob = mock_gcs
+        mock_blob.download_as_text.return_value = "custom content 2"
+
+        content = read_external_content("gs://my-bucket", "test.md")
+
+        assert content == "custom content 2"
+        mock_client.bucket.assert_called_once_with("my-bucket")
+        mock_bucket.blob.assert_called_once_with("test.md")
+
+    def test_read_external_content_gcs_not_found(self, mock_gcs):
+        from google.cloud.exceptions import NotFound
+
+        _, _, mock_blob = mock_gcs
+        mock_blob.download_as_text.side_effect = NotFound("Blob not found")
+
+        content = read_external_content("gs://my-bucket", "test.md")
+
+        assert content is None
 
     def test_read_package_content_success(self):
         # Read actual content from the package

--- a/uv.lock
+++ b/uv.lock
@@ -474,12 +474,13 @@ wheels = [
 
 [[package]]
 name = "datacommons-mcp"
-version = "1.1.7"
+version = "1.2.0"
 source = { editable = "packages/datacommons-mcp" }
 dependencies = [
     { name = "datacommons-client" },
     { name = "fastapi" },
     { name = "fastmcp" },
+    { name = "google-cloud-storage" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dateutil" },
@@ -500,6 +501,7 @@ requires-dist = [
     { name = "datacommons-client", specifier = ">=2.1.6" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastmcp" },
+    { name = "google-cloud-storage" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.4" },


### PR DESCRIPTION
* Added support for reading files from GCS buckets using `gs://` paths for server and tool instructions.
* Updated `.env.sample` to document GCS support for `DC_INSTRUCTIONS_DIR`.
* Manually tested by uploading test instructions to GCS.
   + https://screenshot.googleplex.com/3Z3YquKE8ZVwuJh
   + https://screenshot.googleplex.com/9DmpVdnzNXqkAfu


